### PR TITLE
Adding import for subprocess

### DIFF
--- a/scripts/macOSLAPS
+++ b/scripts/macOSLAPS
@@ -30,6 +30,7 @@ from SystemConfiguration import (SCDynamicStoreCreate,
 import time
 import plistlib
 import os
+import subprocess
 import sys
 import json
 from datetime import datetime, timedelta


### PR DESCRIPTION
I was getting the following error when running the preflight script:
```
ERROR:global name 'subprocess' is not defined
```