### PR TITLE
Add error handling to password change

### DIFF
--- a/scripts/macOSLAPS
+++ b/scripts/macOSLAPS
@@ -194,13 +194,23 @@ class macOSLAPS(object):
                 # Connect to Local Node
                 local_node, error = ODNode.nodeWithSession_name_error_(
                     ODSession.defaultSession(), '/Local/Default', None)
+                if error:
+                    log_error('Error getting local node: %s', error)
                 # Pull Local Administrator Record
                 local_admin_change, error = local_node.\
                     recordWithRecordType_name_attributes_error_(
                         kODRecordTypeUsers, local_admin, None, None)
+                if error:
+                    log_error('Error getting local admin record: %s', error)
                 # Change the password for the account
-                local_admin_change.changePassword_toPassword_error_(
+                result, error = local_admin_change.changePassword_toPassword_error_(
                     None, password, None)
+                if error:
+                    log_error('Error changing local admin password: %s', error)
+                if result:
+                    log_info(' Password change was successful')
+                else:
+                    raise RuntimeError('Password change failed')
                 # Set expiration time in plist
                 plistout['dateexpires'] = epoch_expiration_time
                 log_info(' Password change has been completed. '

--- a/scripts/macOSLAPS
+++ b/scripts/macOSLAPS
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/munkireport/munkireport-python2
 '''LAPS for macOS devices'''
 # pylint: disable=C0103, E0611, W0703
 # ############################################################


### PR DESCRIPTION
When an account has a SecureToken, `changePassword:toPassword:error:` fails with "Credential cannot update user's SecureToken". As there is no checking of the return value, the script will continue and uploaded the new password to the MunkiReport server, while keeping the old password set on the LAPS account, causing them to diverge.

This adds rudimentary error handling which logs any errors and aborts failed password rotation.