### PR TITLE
Add CSRF Token to Post action in remote management

### DIFF
--- a/views/laps_admin.php
+++ b/views/laps_admin.php
@@ -287,6 +287,7 @@ function saveAdmin(serialNumber, resetPassword)
     var url = appUrl + '/module/laps/save_admin_info/'+serialNumber;
     xhr.open("POST", url, true);
     xhr.setRequestHeader("Content-type", "application/json");
+    xhr.setRequestHeader("x-csrf-token", document.querySelector('meta[name="csrf-token"]').content);    
     xhr.send(save_info); 
 }
     


### PR DESCRIPTION
This PR adds the current CSRF Token to the Post request when using any of the Remote Management features. 

Without this, in a simple docker compose setup, munkireport returned a 403 Error because csrf verification failed. 

I am no professional js developer, so i am not sure this is the right way to do it. 
Hopefully it is though